### PR TITLE
Arrumando o operador < dos Pontos

### DIFF
--- a/Geometria Computacional/Pontos.md
+++ b/Geometria Computacional/Pontos.md
@@ -139,7 +139,7 @@ typedef struct _Point {
 
 bool operator<(const Point& p, const Point& q)
 {
-    return (fabs(p.x - q.x) < EPS) ? (q.y - p.y) > -EPS : q.x - p.x > -EPS);
+    return (equals(p.x - q.x)) ? (q.y - p.y) > EPS : q.x - p.x > EPS);
 }
 
 ```


### PR DESCRIPTION
Como o @duerno falou no slack, para ser estritamente menor que, é só fazer b - a > EPS

http://unofficial-competition-guide.readthedocs.io/en/latest/basic-geometry.html#floating-point-comparision