### PR TITLE
Correção do link da questão do URI

### DIFF
--- a/Estruturas_de_Dados/problems/TR-3/referencias.tex
+++ b/Estruturas_de_Dados/problems/TR-3/referencias.tex
@@ -3,7 +3,7 @@
     \begin{enumerate}
         \item \href{https://www.urionlinejudge.com.br/judge/pt/problems/view/1195}{URI 1195 -- Árvore Binária de Busca}
 
-        \item \href{https://www.urionlinejudge.com.br/repository/UOJ_1466.html}{URI 1466 -- Percurso em Árvore por Nível}
+        \item \href{https://www.urionlinejudge.com.br/judge/pt/problems/view/1466}{URI 1466 -- Percurso em Árvore por Nível}
 
         \item \href{https://www.urionlinejudge.com.br/judge/pt/problems/view/1191}{URI 1191 -- Recuperação da Árvore}
 


### PR DESCRIPTION
O link anterior levava para o html do repositório.