### PR TITLE
Add const to private BST search methods

### DIFF
--- a/Estruturas_de_Dados/slides/TR-3/recursive_search.cpp
+++ b/Estruturas_de_Dados/slides/TR-3/recursive_search.cpp
@@ -1,4 +1,4 @@
-bool search(Node *node, const T& info)
+bool search(Node *node, const T& info) const
 {
     if (node == nullptr) return false;
 

--- a/Estruturas_de_Dados/slides/TR-3/search.cpp
+++ b/Estruturas_de_Dados/slides/TR-3/search.cpp
@@ -8,7 +8,7 @@ private:
 
     Node *root;
 
-    bool search(Node *node, const T& info)
+    bool search(Node *node, const T& info) const
     {
         while (node)
         {


### PR DESCRIPTION
Fix **argument discards qualifiers** error due to ```const``` absence in the BST private search methods