### PR TITLE
 Correção do erro ‘Point’ without an argument list

### DIFF
--- a/Geometria_Computacional/slides/LN-1/contains.cpp
+++ b/Geometria_Computacional/slides/LN-1/contains.cpp
@@ -4,7 +4,7 @@ template<typename T>
 struct Line {
     // Membros e construtor
 
-    bool contains(const Point& P) const
+    bool contains(const Point<T>& P) const
     {
         return equals(a*P.x + b*P.y + c, 0);
     }

--- a/Geometria_Computacional/slides/LN-1/geral2.cpp
+++ b/Geometria_Computacional/slides/LN-1/geral2.cpp
@@ -4,7 +4,7 @@ template<typename T>
 struct Line {
     T a, b, c;
 
-    Line(const Point& P, const Point& Q)
+    Line(const Point<T>& P, const Point<T>& Q)
         : a(P.y - Q.y), b (Q.x - P.x), c(P.x * Q.y - Q.x * P.y)
     {
     }

--- a/Geometria_Computacional/slides/LN-1/line2.cpp
+++ b/Geometria_Computacional/slides/LN-1/line2.cpp
@@ -5,7 +5,7 @@ struct Line {
     T m, b;
     bool vertical;
 
-    Line(const Point& P, const Point& Q) : vertical(false)
+    Line(const Point<T>& P, const Point<T>& Q) : vertical(false)
     {
         if (equals(P.x, Q.x))
         {

--- a/Geometria_Computacional/slides/LN-1/vector.cpp
+++ b/Geometria_Computacional/slides/LN-1/vector.cpp
@@ -7,6 +7,6 @@ struct Vector
 
     Vector(T xv, T yv) : x(xv), y(yv) {}
 
-    Vector(const Point& A, const Point& B) 
+    Vector(const Point<T>& A, const Point<T>& B) 
         : x(B.x - A.x), y(B.y - A.y) {}
 };


### PR DESCRIPTION
Em alguma funções os parâmetros não especificava o template da classe