### PR TITLE
Correção na relação da parentesco após a rotação

### DIFF
--- a/Estruturas_de_Dados/slides/TR-5/rb.cpp
+++ b/Estruturas_de_Dados/slides/TR-5/rb.cpp
@@ -47,8 +47,8 @@ private:
         C->parent = G;
         P->parent = C;
 
-        if (C->left)
-            C->left->parent = P;
+        if (P->right)
+            P->right->parent = P;
     }
 
     void rotate_right(Node *G, Node *P, Node *C)
@@ -62,8 +62,8 @@ private:
         C->parent = G;
         P->parent = C;
 
-        if (C->right)
-            C->right->parent = P;
+        if (P->left)
+            P->left->parent = P;
     }
 
 public:


### PR DESCRIPTION
Nos casos em que P->right recebe a subárvore C->left é preciso definir P como novo parent.
O mesmo para o caso em que P->left recebe C->right.