### PR TITLE
Modificações nas funções count_inversions e compression

### DIFF
--- a/Estruturas_de_Dados/slides/FT-2/compression.cpp
+++ b/Estruturas_de_Dados/slides/FT-2/compression.cpp
@@ -1,5 +1,5 @@
 template<typename T>
-map<T, int> compression(const vector<T>& as, int N)
+long long count_inversions_compression(const vector<T>& as)
 {
     vector<T> xs(as);
 
@@ -7,8 +7,20 @@ map<T, int> compression(const vector<T>& as, int N)
 
     map<T, int> f;
 
-    for (int i = 1; i <= N; ++i)
-        f[xs[i]] = i;
+    for (size_t i = 1; i <= as.size(); ++i)
+        f[ xs[i-1] ] = i;
 
-    return f;
-} 
+    BITree<T> ft(as.size());
+
+    long long inversions = 0;
+
+    for(size_t i=0; i<as.size(); i++)
+    {
+        auto comp_val = f[as[i]];
+
+        inversions += ft.RSQ(comp_val+1, as.size());
+        ft.add(comp_val, 1);
+    }
+
+    return inversions;
+}

--- a/Estruturas_de_Dados/slides/FT-2/inversions.cpp
+++ b/Estruturas_de_Dados/slides/FT-2/inversions.cpp
@@ -1,12 +1,13 @@
 template<typename T>
-long long count_inversions(const vector<T>& as, int N, int M)
+long long count_inversions(const vector<T>& as)
 {
+    T _max = *max_element(as.begin(), as.end());
+    BITree<T> ft(_max);
+    
     long long inversions = 0;
-    BITree<T> ft(M);
-
-    for (int i = 1; i <= N; ++i)
+    for (size_t i = 0; i < as.size(); ++i)
     {
-        inversions += ft.RSQ(as[i] + 1, M);
+        inversions += ft.RSQ(as[i] + 1, _max);
         ft.add(as[i], 1);
     }
 


### PR DESCRIPTION
Para a função count_inversions, corrigi o problema dos casos de teste com repetições.
Na versão anterior, para casos de teste já ordenados {1,2,3}, a função retornava 2 inversões.

Na função compression, acredito que o objetivo era somente retornar os valores do vetor mapeados, mas achei interessante modificar a função para retornar a quantidade de inversões.