### PR TITLE
Correção na verificação do ponteiro de arquivo out

### DIFF
--- a/Introducao/slides/PT-2/criptofile.c
+++ b/Introducao/slides/PT-2/criptofile.c
@@ -1,3 +1,11 @@
+/*
+ * Compile com a linha abaixo:
+ *
+ *  $ gcc cripto.c main.c -o cipherfile
+ *  $ gcc cripto.c main.c -o decipherfile
+ *
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -22,8 +30,8 @@ int main(int argc, char *argv[]) {
 
     out = fopen(argv[2], "w");
 
-    if (!in) {
-        fprintf(stderr, "Erro ao abrir %s para escrita\n", argv[1]);
+    if (!out) {
+        fprintf(stderr, "Erro ao abrir %s para escrita\n", argv[2]);
         fclose(in);
         return -3;
     }


### PR DESCRIPTION
Acredito que o objetivo do if que mudei era verificar se o ponteiro de arquivo _out_ foi alocado, e não o ponteiro de arquivo _in_.

Coloquei um comentário explicando quais nomes são válidos o programa funcionar devidamente.