### PR TITLE
Correção de erro de digitação

### DIFF
--- a/Matematica/funcoes_multiplicativas/codes/sigma2.cpp
+++ b/Matematica/funcoes_multiplicativas/codes/sigma2.cpp
@@ -1,4 +1,4 @@
-long long number_of_divisors(long long n)
+long long sum_of_divisors(long long n)
 {
     long long res = 0;
 


### PR DESCRIPTION
Troca `number_of_divisors` por `sum_of_divisors` na função sigma otimizada 