### PR TITLE
mudança tipo de retorno da função find_set da ufds

### DIFF
--- a/Estruturas_de_Dados/slides/ufds/codes/compression.h
+++ b/Estruturas_de_Dados/slides/ufds/codes/compression.h
@@ -1,4 +1,4 @@
-    void find_set(int x)
+    int find_set(int x)
     {
         return x == ps[x] ? x : (ps[x] = find_set(ps[x]));
     }


### PR DESCRIPTION
**O que foi feito?**
O tipo de retorno da função `find_set()` foi trocado de `void` para `int`, visto que no contexto de como a `ufds.h` foi implementada esse seria o tipo correto de retorno.