### PR TITLE
Adicionar tipo genérico no operador de igualdade da classe `Point`

### DIFF
--- a/Geometria_Computacional/slides/pontos/codes/equal.cpp
+++ b/Geometria_Computacional/slides/pontos/codes/equal.cpp
@@ -12,11 +12,11 @@ template<typename T>
 struct Point {
     T x = 0, y = 0;
 
-    bool operator==(const Point& p) const noexcept {
+    bool operator==(const Point<T>& p) const noexcept {
         return equals(x, p.x) && equals(y, p.y);
     }
 
-    bool operator!=(const Point& p) const noexcept {
+    bool operator!=(const Point<T>& p) const noexcept {
         return not (*this == p);
     }
 };


### PR DESCRIPTION
Este Pull Request tem como intuito adicionar tipos genéricos que estão faltando no operador de igualdade `==` na classe `Point` no código sobre igualdade de pontos (deixei esses passarem no meu último PR).

Anteciosamente,
Caio.