### PR TITLE
Diminuição da constante MAXMATCH com bijeção

### DIFF
--- a/Paradigmas/problems/SPOJ_MAXMATCH/codes/MAXMATCH-BIJECTIVE.cpp
+++ b/Paradigmas/problems/SPOJ_MAXMATCH/codes/MAXMATCH-BIJECTIVE.cpp
@@ -1,0 +1,93 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+
+typedef long long ll;
+
+#define all(x) x.begin(), x.end()
+#define MSOne(S) (1ull << (63 - __builtin_clzll(S)))
+#define fastio ios_base::sync_with_stdio(0); \
+               cin.tie(0); \
+               cout.tie(0)
+
+// FFT - CP Algorithm
+using cd = complex<double>;
+const double PI = acos(-1);
+
+void fft(vector<cd>& a, bool invert) {
+    int n = a.size();
+
+    for (int i = 1, j = 0; i < n; i++) {
+        int bit = n >> 1;
+        for (; j & bit; bit >>= 1)
+            j ^= bit;
+        j ^= bit;
+
+        if (i < j)
+            swap(a[i], a[j]);
+    }
+
+    for (int len = 2; len <= n; len <<= 1) {
+        double ang = 2 * PI / len * (invert ? -1 : 1);
+        cd wlen(cos(ang), sin(ang));
+        for (int i = 0; i < n; i += len) {
+            cd w(1);
+            for (int j = 0; j < len / 2; j++) {
+                cd u = a[i + j], v = a[i + j + len / 2] * w;
+                a[i + j] = u + v;
+                a[i + j + len / 2] = u - v;
+                w *= wlen;
+            }
+        }
+    }
+
+    if (invert) {
+        for (cd& x : a)
+            x /= n;
+    }
+}
+
+string abc = "abc", acb = "acb";
+int main() {
+    fastio;
+
+    string s;
+    cin >> s;
+    string r(s);
+
+    int N = s.size();
+    ll size = MSOne((N + N) << 1);
+
+    vector<cd> fs(size, 0), fr(size, 0);
+    for (int j = 0; j < N; j++) {
+        int sh = abc.find(s[j]);
+        double sp = (2 * PI * sh) / 3;
+        fs[j] = cd(cos(sp), sin(sp));
+
+        int rh = acb.find(s[N - j - 1]);
+        double rp = (2 * PI * rh) / 3;
+        fr[j] = cd(cos(rp), sin(rp));
+    }
+    fft(fs, false);
+    fft(fr, false);
+
+    for (int i = 0; i < size; i++) fs[i] *= fr[i];
+    fft(fs, true);
+
+    int mx = 0;
+    vector<int> ms;
+    for (int i = N; i < N + N; i++) {
+        double t = fs[i].real();
+        int tot = 2 * N - i - 1;
+        double p = (tot + 2 * t) / 3.00;
+        int k = (int)round(p);
+        mx = max(mx, k);
+        ms.push_back(k);
+    }
+
+    cout << mx << "\n";
+    for (int i = 0; i < ms.size(); i++) if (ms[i] == mx) cout << i + 1 << " ";
+    cout << "\n";
+
+    return 0;
+}


### PR DESCRIPTION
A partir da solução tradicional de _Hamming Distance_ utilizando FFT, tendo T como texto principal e P como o padrão a ser buscado nas substrings de tamanho |P| em T, criamos um vetor binário (VT&alpha; , VP&alpha;), para cada letra _&alpha;_ do alfabeto existente em T e P. Após isso, executamos a operação $IFFT(FFT(VT&alpha;) &bull; FFT(VP&alpha;))$ em cada vetor binário criado e somamos para cada índice _i_ a resposta da parte real. Nisso, serão executadas &delta; dessas operações em que &delta; é o tamanho do alfabeto.

Entretanto, utilizando bijeção e a notação polar dos números complexos, podemos reduzir o número de execuções para $&delta;/2$, nessa implementação vamos mapear cada letra do alfabeto para um ângulo dentro do circulo trigonométrico, mas essa escolha deve ser feita de modo que quando o mapeamento de letras iguais nas strings T e P são multiplicados no processo $FFT(VT&alpha;) &bull; FFT(VP&alpha;)$, haja sempre uma contribuição padrão para a parte real, e da mesma forma, haja uma outra contribuição padrão no caso da multiplicação dos mapeamentos de letras diferentes. Para conseguir esse comportamento, podemos dividir o círculo em 3 blocos iguais, sendo esses $(0, \frac{2 \pi}{3}, \frac{4 \pi}{3})$, assim, teremos os mapeamentos $(1 + i \cdot 0, -\frac{1}{2} + \frac{\sqrt{3}i}{2}, -\frac{1}{2} - \frac{\sqrt{3}i}{2})$.

Agora, digamos que estamos com um alfabeto $&delta; = 3$ composto por $(a, b, c)$, então para o texto T podemos fazer o mapeamento por índice normal, ou seja, $(a = 0, b = 1, c = 2)$. Após isso, faremos o mapeamento na string P trocando os índices de 1 e 2, resultando em $(a = 0, b = 2, c = 1)$, e então para cada letra mapear nos blocos usando $\frac{2 \pi k}{3}$, sendo $k$ o índice da letra em T ou em P.

Notação: $w^k = cos(\frac{2 \pi k}{3}) + i \cdot sin(\frac{2 \pi k}{3})$.

Nisso, observa-se que se tivermos uma multiplicação de letras iguais nos mapeamentos a contribuição da parte real será de 1, ou seja:

$a \cdot a = w^0 \cdot w^0 = 1$
$b \cdot b = w^1 \cdot w^2 = 1$
$c \cdot c = w^2 \cdot w^1 = 1$

E para cada multiplicação de letras diferentes vamos ter uma contribuição de $-\frac{1}{2}$ na parte real, um exemplo seria:

$b \cdot c = w^1 \cdot w^1 = -\frac{1}{2} - \frac{\sqrt{3} i}{2}$

Então, é possível encontrar uma fórmula geral que, dado o tamanho atual $t$ de comparaçãos da string P sobre o texto T e o resultado da parte real da convolução em cada índice $p$, podemos calcular o resultado final da _Hamming Distance_. Essa, é dada pelo seguinte: 

$$round(\frac{t + 2 v[p].real()}{&delta;})$$

Como exemplo podemos usar o caso de teste da MAXMATCH:

T = caccacaa
P = caccacaa
&delta; = 3

No seguinte momento, temos 4 corretos e 1 incorreto, então a soma seria $v[p].real() \approx 4 \cdot 1 - 1 \cdot \frac{1}{2} \approx 3.5$ e o tamanho atual sendo comparado $t = 5$, então o resultado final é $round((5 + 2 \cdot 3.5) / 3) = 4$

```
caccacaa
   caccacaa
```

Em alfabetos maiores podemos apenas separar em grupos de 2 letras e aplicar as operações e somar os resultados, assim como normalmente fazíamos, mas agora em menos passos.

Referência: [FFT-based algorithms for the string matching with mismatches problem](https://www.sciencedirect.com/science/article/pii/S0196677405000180)

Obs: Algumas modificações foram feitas a partir da metodologia do artigo para aplicação no MAXMATCH. 